### PR TITLE
Add section assignment block for multi-selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -2893,6 +2893,27 @@
                 modelMaterials.forEach(mat => {
                     materialOptionsHtml += `<option value="${mat.id}">${mat.name} (${mat.standard})</option>`;
                 });
+
+                let sectionOptionsHtml = '<option value="">Не выбрано</option>';
+                modelSections.forEach(sec => {
+                    sectionOptionsHtml += `<option value="${sec.id}">${sec.name} (${sec.standard})</option>`;
+                });
+
+                const uniqueSectionIds = new Set(selectedElements.map(sel => sel.element.sectionId).filter(id => id));
+                let assignedSectionName;
+                if (uniqueSectionIds.size === 1) {
+                    const secId = Array.from(uniqueSectionIds)[0];
+                    const sec = modelSections.find(s => s.id === secId);
+                    assignedSectionName = sec ? `${sec.name} (${sec.standard})` : 'Нет';
+                } else if (uniqueSectionIds.size === 0) {
+                    assignedSectionName = 'Нет';
+                } else {
+                    assignedSectionName = 'разные';
+                }
+
+                const uniqueAngles = new Set(selectedElements.map(sel => sel.element.betaAngle !== undefined ? sel.element.betaAngle : 0));
+                const betaAngleDisplay = uniqueAngles.size === 1 ? Array.from(uniqueAngles)[0] : 'разные';
+
                 const currentForceDisplayUnit = forceUnitsSelect.value;
                 const currentLengthDisplayUnit = unitsSelect.value;
                 const currentDistributedForceUnit = `${currentForceDisplayUnit}/${currentLengthDisplayUnit}`;
@@ -2905,6 +2926,26 @@
                             </select>
                             <button id="applyMaterialToSelectedBtn" class="px-4 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-50">Применить</button>
                         </div>
+                    </div>
+                    <div class="property-group">
+                        <h4 class="font-bold text-gray-700 mb-2">Назначение сечения</h4>
+                        <div class="flex items-center gap-2 mb-2">
+                            <select id="multiSectionSelect" class="flex-grow form-select block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm rounded-md shadow-sm">
+                                ${sectionOptionsHtml}
+                            </select>
+                            <button id="applySectionToSelectedBtn" class="px-4 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-50">Выбрать сечение</button>
+                        </div>
+                        <div class="flex items-center gap-2 mb-2">
+                            <select id="multiBetaAngleSelect" class="form-select block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm rounded-md shadow-sm">
+                                <option value="0">0</option>
+                                <option value="90">90</option>
+                                <option value="180">180</option>
+                                <option value="270">270</option>
+                            </select>
+                            <button id="applyBetaAngleToSelectedBtn" class="px-4 py-2 bg-blue-500 text-white rounded-md hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-50">Поменять угол сечения</button>
+                        </div>
+                        <p class="text-sm text-gray-700">Назначенное сечение: <span id="multiAssignedSectionDisplay" class="font-semibold italic">${assignedSectionName}</span></p>
+                        <p class="text-sm text-gray-700 mt-1">Угол сечения: <span id="multiBetaAngleDisplay" class="font-semibold italic">${betaAngleDisplay}</span></p>
                     </div>
                     <div class="property-group">
                         <h4 class="font-bold text-gray-700 mb-2">Распределенные нагрузки</h4>
@@ -2935,6 +2976,38 @@
                         });
                         updatePropertiesPanel();
                         draw();
+                    });
+                }
+
+                const applySectionBtn = document.getElementById('applySectionToSelectedBtn');
+                const sectionSelectEl = document.getElementById('multiSectionSelect');
+                if (applySectionBtn && sectionSelectEl) {
+                    applySectionBtn.addEventListener('click', () => {
+                        const secId = sectionSelectEl.value;
+                        selectedElements.forEach(sel => {
+                            if (sel.type === 'line') {
+                                sel.element.sectionId = secId || null;
+                            }
+                        });
+                        updatePropertiesPanel();
+                        draw();
+                    });
+                }
+
+                const applyBetaBtn = document.getElementById('applyBetaAngleToSelectedBtn');
+                const betaSelectEl = document.getElementById('multiBetaAngleSelect');
+                if (applyBetaBtn && betaSelectEl) {
+                    applyBetaBtn.addEventListener('click', () => {
+                        const angle = parseInt(betaSelectEl.value, 10);
+                        if (!isNaN(angle)) {
+                            selectedElements.forEach(sel => {
+                                if (sel.type === 'line') {
+                                    sel.element.betaAngle = angle;
+                                }
+                            });
+                            updatePropertiesPanel();
+                            draw();
+                        }
                     });
                 }
 


### PR DESCRIPTION
## Summary
- allow setting section for multiple selected elements
- show `разные` if selected elements have different sections or beta angles

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684e2c4da508832c95ff4d2d42a38319