### PR TITLE
Hide tooltip when context menu or modal is open

### DIFF
--- a/index.html
+++ b/index.html
@@ -2194,8 +2194,8 @@
         function handleContextMenu(e) {
             e.preventDefault();
             const rect = canvas.getBoundingClientRect();
-            const worldCoords = screenToWorld(e.clientX - rect.left, e.clientY - rect.top); 
-            contextMenuTarget = findElementAt(worldCoords.x, worldCoords.y); 
+            const worldCoords = screenToWorld(e.clientX - rect.left, e.clientY - rect.top);
+            contextMenuTarget = findElementAt(worldCoords.x, worldCoords.y);
 
             if (contextMenuTarget) {
                 deleteNodeItem.style.display = contextMenuTarget.type === 'node' ? 'block' : 'none';
@@ -2204,6 +2204,7 @@
                 customContextMenu.style.left = `${e.clientX}px`;
                 customContextMenu.style.top = `${e.clientY}px`;
                 customContextMenu.classList.remove('hidden');
+                tooltip.classList.add('hidden');
             } else {
                 hideContextMenu();
             }
@@ -2301,6 +2302,7 @@
                 nodeToCopy = contextMenuTarget.element;
                 copyNodeModal.classList.remove('hidden');
                 hideContextMenu();
+                tooltip.classList.add('hidden');
             }
         }
 


### PR DESCRIPTION
## Summary
- ensure the tooltip is hidden when the context menu opens
- also hide the tooltip when launching the copy-node modal

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68501b40f3d0832cabbdb4f8c01a45e5